### PR TITLE
Include algorithm in lib/path.cc for newer LLVM

### DIFF
--- a/lib/path.cc
+++ b/lib/path.cc
@@ -15,6 +15,7 @@
 
 #include "path.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 


### PR DESCRIPTION
In future LLVM releases (around r457743), std::any_of
will only be included through the <algorithm> standard header.
Previously, this file compiled due to a transitive include
via other standard library headers (perhaps in this case, string_view)

See https://buganizer.corp.google.com/issues/228085014#comment9 for
this error in ChromeOS.

This may need to be merged into the chromeos branch rather than
main. I'm uncertain of the process.