### PR TITLE
cache: use $TMPDIR by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ yet, **mount-zip** creates it first. If no mount point is provided,
 :   original encoding of file names
 
 **-\-cache=DIR**
-:   cache directory (default is `/tmp`)
+:   cache directory (default is `$TMPDIR` or `/tmp`)
 
 **-\-precache**
 :   preemptively uncompress and cache data
@@ -609,9 +609,9 @@ sys     0m0.018s
 ```
 
 Decompressed data is cached in a temporary file located in the cache directory
-(`/tmp` by default). The cache directory can be changed with the `--cache=DIR`
-option. The cache file is only created if necessary, and automatically deleted
-when the ZIP is unmounted.
+(`$TMPDIR` or `/tmp` by default). The cache directory can be changed with the
+`--cache=DIR` option. The cache file is only created if necessary, and
+automatically deleted when the ZIP is unmounted.
 
 You can preemtively cache data at mount time by using the `--precache` option.
 

--- a/lib/reader.cc
+++ b/lib/reader.cc
@@ -32,8 +32,14 @@
 #include "path.h"
 #include "scoped_file.h"
 
+static std::string GetEnvOrDefault(const char* env_var,
+                                   const char* default_val) {
+  const char* val = std::getenv(env_var);
+  return val ? val : default_val;
+}
+
 bool Reader::may_cache_ = true;
-std::string Reader::cache_dir_ = "/tmp";
+std::string Reader::cache_dir_ = GetEnvOrDefault("TMPDIR", "/tmp");
 zip_int64_t Reader::reader_count_ = 0;
 
 static void LimitSize(ssize_t* const a, off_t b) {

--- a/main.cc
+++ b/main.cc
@@ -70,7 +70,7 @@ General options:
                            if the encryption or compression method is unsupported
     --encoding=CHARSET     original encoding of file names
     --precache             preemptively uncompress and cache data
-    --cache=DIR            cache dir (default is /tmp)
+    --cache=DIR            cache dir (default is $TMPDIR or /tmp)
     --nocache              no caching of uncompressed data
     -o nospecials          no special files (FIFOs, sockets, devices)
     -o nosymlinks          no symbolic links

--- a/mount-zip.1
+++ b/mount-zip.1
@@ -67,7 +67,7 @@ compression method is unsupported
 original encoding of file names
 .TP
 \f[B]--cache=DIR\f[R]
-cache directory (default is \f[V]/tmp\f[R])
+cache directory (default is \f[V]$TMPDIR\f[R] or \f[V]/tmp\f[R])
 .TP
 \f[B]--precache\f[R]
 preemptively uncompress and cache data


### PR DESCRIPTION
$TMPDIR is the POSIX standard environment variable for setting the
location of the temporary directory.

It is now taken into account for the cache directory.
The cache falls back to /tmp if the variable is not set.
The location can still be overridden with `--cache=DIR` on the CLI.
