### PR TITLE
fix: support leading "./" in filenames

### DIFF
--- a/lib/path.cc
+++ b/lib/path.cc
@@ -165,6 +165,10 @@ bool Path::Normalize(std::string* const dest_path,
     assert(need_prefix);
     Append(dest_path, "ROOT");
     in.remove_prefix(1);
+  } else if (in.starts_with("./")) {
+    in.remove_prefix(2);
+    if (in.empty())
+      return false;
   } else {
     bool parentRelative = false;
     while (in.starts_with("../")) {

--- a/tests/whitebox/filename_validator.cc
+++ b/tests/whitebox/filename_validator.cc
@@ -41,6 +41,8 @@ int main() {
   checkConversion("normal.name", true, "/CUR/normal.name");
   checkConversion("path/to/normal.name", false, "/path/to/normal.name");
   checkConversion("path/to/normal.name", true, "/CUR/path/to/normal.name");
+  checkConversion("./normal.name", false, "/normal.name");
+  checkConversion("./path/to/normal.name", false, "/path/to/normal.name");
 
   checkConvertException(".", false);
   checkConvertException("./", false);


### PR DESCRIPTION
fixes #29

I have added support for leading `./` in filenames by adding a special case. I first tried to handle this in a more generic way by skipping over `part`s equal to `"."` as I mentioned in the issue. That change caused some of the tests in `filename_validator.cc` to fail, and so I took the easy way out because I am lazy.