### PR TITLE
Remove Linux-specific header

### DIFF
--- a/mount-zip.cc
+++ b/mount-zip.cc
@@ -38,7 +38,6 @@
 #include <fuse_opt.h>
 #include <libgen.h>
 #include <limits.h>
-#include <linux/limits.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/syslog.h>


### PR DESCRIPTION
PATH_MAX and NAME_MAX are indirectly defined by limits.h on modern systems (>= SUSv2)

But PATH_MAX / MAXPATHLEN / _POSIX_PATH_MAX have their problems.
Ideally, we should use `pathconf()`, or since POSIX 2008, `realpath(param.cache_dir, NULL);` instead of using a stack buffer and free the buffer later.
