### PR TITLE
Add support for macfuse and macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ DEPS += libzip icu-uc icu-i18n
 LDFLAGS += -Llib -lmountzip
 LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
-CXXFLAGS += -Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers -pedantic -std=c++20
+CXXFLAGS += -Wall -Wextra -Wno-nullability-extension -Wno-sign-compare -Wno-missing-field-initializers -pedantic -std=c++20
 CXXFLAGS += -D_FILE_OFFSET_BITS=64 
 
 ifeq ($(DEBUG), 1)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -19,7 +19,7 @@ DEST = libmountzip.a
 PKG_CONFIG ?= pkg-config
 DEPS = libzip icu-uc icu-i18n
 CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
-CXXFLAGS += -Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers -pedantic -std=c++20
+CXXFLAGS += -Wall -Wextra -Wno-nullability-extension -Wno-sign-compare -Wno-missing-field-initializers -pedantic -std=c++20
 CXXFLAGS += -D_FILE_OFFSET_BITS=64 
 ifeq ($(DEBUG), 1)
 CXXFLAGS += -O0 -g

--- a/mount-zip.cc
+++ b/mount-zip.cc
@@ -32,8 +32,25 @@
 #include <new>
 #include <string_view>
 
+#ifdef __APPLE__
+
+#ifndef typeof // work around the -pedantic -std=c++20
+#define typeof(x) __typeof__(x)
+#endif
+
+#ifdef FUSE_USE_VERSION
+#define FUSE_DARWIN_ENABLE_EXTENSIONS 0
+#endif
+
+#endif
+
 #include <fuse.h>
 #include <fuse_opt.h>
+
+#ifdef __APPLE__
+#undef typeof
+#endif
+
 #include <libgen.h>
 #include <limits.h>
 #include <string.h>


### PR DESCRIPTION
Emulate the missing `memfd_create` with `shm_open`.

The `#define typeof(x) __typeof__(x)` is a workaround for `-pedantic -std=c++20` does not allow use of `typeof()` in macfuse header files. I have opened an issue https://github.com/macfuse/macfuse/issues/1091 and if that is resolved for their new release that can be removed.
