### PR TITLE
Add missing #include <boost/container_hash/hash.hpp> in tree.cc

### DIFF
--- a/lib/tree.cc
+++ b/lib/tree.cc
@@ -41,6 +41,8 @@
 #include <unistd.h>
 #include <zip.h>
 
+#include <boost/container_hash/hash.hpp>
+
 #include "error.h"
 #include "extra_field.h"
 #include "file_descriptor.h"


### PR DESCRIPTION
The title say everything.

This is a tiny fix to make "it works on my system™" which is an ArchLinux with boost package version 1.91.0-1.